### PR TITLE
replaced deprecated 'provided' dependency with 'compileOnly'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,5 +28,5 @@ android {
 }
 
 dependencies {
-    provided "com.facebook.react:react-native:+"
+    compileOnly "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
Replaced deprecated 'provided' dependency with 'compileOnly'. This is needed in order to build an app with react-native v0.68