### PR TITLE
fix: remove duplicate dev and non-dev type packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
     "@react-native-community/eslint-config": "^2.0.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^26.0.0",
-    "@types/react": "^18.0.21",
-    "@types/react-native": "^0.70.6",
     "@types/react-test-renderer": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",


### PR DESCRIPTION
Should fix

```
warning package.json: "dependencies" has dependency "@types/react" with range "^18.0.24" that collides with a dependency in "devDependencies" of the same name with version "^18.0.21"
warning @sourcetoad/react-native-sketch-canvas@1.0.1: "dependencies" has dependency "@types/react" with range "^18.0.24" that collides with a dependency in "devDependencies" of the same name with version "^18.0.21"
```

As these are already non-dev packages.