### PR TITLE
fix: use proper getBase64 on example 2

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -321,6 +321,7 @@ export default class example extends Component<any, ExampleState> {
                       false,
                       true,
                       true,
+                      true,
                       (err: any, result: any) => {
                         console.log(result);
                       },


### PR DESCRIPTION
This was missing a parameter which was causing.

>  ERROR  Invariant Violation: Cannot have a non-function arg after a function arg., js engine: hermes
