### PR TITLE
build: add gitignore for android gradlew

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,5 @@
+# Running Android in isolation in IDE causes these to be generated.
+# They wouldn't be generated in usage of the library in React Native.
+gradlew
+gradlew.bat
+gradle/wrapper/*


### PR DESCRIPTION
I found that when I wanted to debug the Java - I couldn't get symbols to load without gradle sync running. This then generated these files.

You'd never have these in compilation of a React Native application, since this is a child dependency and if you are running it in isolation - we don't have to commit them.