### PR TITLE
build: add back prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "prepare": "npm run build",
     "example:start": "cd example && npm start",
     "example:android": "cd example && npm run android",
     "example:ios": "cd example && npm run ios",


### PR DESCRIPTION
Installed latest version (v1.1.1) and the supposed to be generated `lib/` folder by `bob build` command during installation is not present causing unresolvable dependency warning