### PR TITLE
Update `addPath` method so it will also work on newarch interop

### DIFF
--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvasManager.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvasManager.m
@@ -74,16 +74,19 @@ RCT_EXPORT_METHOD(addPoint:(nonnull NSNumber *)reactTag x: (float)x y: (float)y)
 
 RCT_EXPORT_METHOD(addPath:(nonnull NSNumber *)reactTag pathId: (int) pathId strokeColor: (UIColor*) strokeColor strokeWidth: (int) strokeWidth points: (NSArray*) points)
 {
-    NSMutableArray *cgPoints = [[NSMutableArray alloc] initWithCapacity: points.count];
+    NSMutableArray *cgPoints = [[NSMutableArray alloc] initWithCapacity:points.count];
+        
     for (NSString *coor in points) {
         @autoreleasepool {
-            NSArray *coorInNumber = [coor componentsSeparatedByString: @","];
-            [cgPoints addObject: [NSValue valueWithCGPoint: CGPointMake([coorInNumber[0] floatValue], [coorInNumber[1] floatValue])]];
-            [self runCanvas:reactTag block:^(RNSketchCanvas *canvas) {
-                [canvas addPath: pathId strokeColor: strokeColor strokeWidth: strokeWidth points: cgPoints];
-            }];
+            NSArray *coorInNumber = [coor componentsSeparatedByString:@","];
+            CGPoint point = CGPointMake([coorInNumber[0] floatValue], [coorInNumber[1] floatValue]);
+            [cgPoints addObject:[NSValue valueWithCGPoint:point]];
         }
     }
+    
+    [self runCanvas:reactTag block:^(RNSketchCanvas *canvas) {
+        [canvas addPath:pathId strokeColor:strokeColor strokeWidth:strokeWidth points:cgPoints];
+    }];
 }
 
 RCT_EXPORT_METHOD(newPath:(nonnull NSNumber *)reactTag pathId: (int) pathId strokeColor: (UIColor*) strokeColor strokeWidth: (int) strokeWidth)


### PR DESCRIPTION
- on newarch interop `addPath` doesn't behave the same and it will only draw the first point and skip the rest of the points
- the same code works if I disable newarch
- unsure how will this impact the memory since current solution will now draw the paths right after building the points w/c actually fixed the issue