### PR TITLE
Rn79 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "version": "2.1.2",
   "description": "react-native-sketch-canvas allows you to draw / sketch on both iOS and Android devices and sync the drawing data between users. Of course you can save as image.",
   "author": "Terry Lin",
+  "react-native": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",
   "types": "./lib/typescript/module/index.d.ts",
@@ -14,12 +15,12 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
-        "source": "./src/index.tsx",
+        "react-native": "./src/index.tsx",
         "types": "./lib/typescript/module/index.d.ts",
         "default": "./lib/module/index.js"
       },
       "require": {
-        "source": "./src/index.tsx",
+        "react-native": "./src/index.tsx",
         "types": "./lib/typescript/commonjs/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "version": "2.1.2",
   "description": "react-native-sketch-canvas allows you to draw / sketch on both iOS and Android devices and sync the drawing data between users. Of course you can save as image.",
   "author": "Terry Lin",
-  "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",
   "types": "./lib/typescript/module/index.d.ts",
@@ -15,10 +14,12 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "source": "./src/index.tsx",
         "types": "./lib/typescript/module/index.d.ts",
         "default": "./lib/module/index.js"
       },
       "require": {
+        "source": "./src/index.tsx",
         "types": "./lib/typescript/commonjs/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }


### PR DESCRIPTION
Fixes error:

```
SketchCanvasNativeComponent.js: Could not find component config for native component
```

- https://metrobundler.dev/docs/package-exports/#replacing-browser-and-react-native-fields