### PR TITLE
React19 + Typescript fixes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -305,7 +305,9 @@ export default class RNSketchCanvas extends React.Component<
           </View>
         </View>
         <SketchCanvas
-          ref={(ref) => (this._sketchCanvas = ref)}
+          ref={(ref) => {
+            this._sketchCanvas = ref;
+          }}
           style={this.props.canvasStyle}
           strokeColor={
             this.state.color +

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 
 export type ImageType = 'png' | 'jpg';


### PR DESCRIPTION
- Fixes react 19 ref cleanup TS error
- Dropped global `JSX` usage and imports `JSX` type from react

[React19 Cleanup function refs](https://react.dev/blog/2024/12/05/react-19#cleanup-functions-for-refs)
>Due to the introduction of ref cleanup functions, returning anything else from a ref callback will now be rejected by TypeScript. The fix is usually to stop using implicit returns, for example:

```
- <div ref={current => (instance = current)} />
+ <div ref={current => {instance = current}} />
```
>The original code returned the instance of the HTMLDivElement and TypeScript wouldn’t know if this was supposed to be a cleanup function or if you didn’t want to return a cleanup function.