### PR TITLE
fix: incomplete path not included on saving

### DIFF
--- a/ios/SketchCanvas/RNSketchCanvas.m
+++ b/ios/SketchCanvas/RNSketchCanvas.m
@@ -478,6 +478,11 @@
         CGContextDrawImage(context, targetRect, _frozenImage);
         CGContextDrawImage(context, targetRect, _translucentFrozenImage);
         
+        // Include current incomplete path in saved image
+        if (_currentPath) {
+            [_currentPath drawInContext:context];
+        }
+        
         if (includeText) {
             @autoreleasepool {
                 for (CanvasText *text in _arrTextOnSketch) {
@@ -513,6 +518,11 @@
         
         CGContextDrawImage(context, rect, _frozenImage);
         CGContextDrawImage(context, rect, _translucentFrozenImage);
+        
+        // Include current incomplete path in saved image
+        if (_currentPath) {
+            [_currentPath drawInContext:context];
+        }
         
         if (includeText) {
             for (CanvasText *text in _arrTextOnSketch) {


### PR DESCRIPTION
# Fix Sketch Canvas Save Functionality - Incomplete Strokes Now Preserved

## Description
Fixed a critical issue where incomplete drawing strokes were not included in saved images, causing user work to be lost when save operations were called before stroke completion.

## Issue Analysis
The original implementation had a fundamental design flaw where the save functionality only captured completed paths from `_frozenImage` but ignored incomplete strokes in `_currentPath`. This created a timing-dependent failure where:

1. **Visual Inconsistency**: Users could see strokes on screen that wouldn't appear in saved images
2. **Data Loss**: Incomplete strokes were lost during save operations  
3. **Poor UX**: "What you see is what you get" principle was violated

**Root Cause**: The code assumed every drawing gesture would complete normally via `onPanResponderRelease`, but real-world scenarios (system interruptions, app switching, gesture conflicts) could prevent this from happening.

## Solution
Enhanced the `createImageWithTransparentBackground` method to include incomplete paths in saved images:

```objective-c
// Before: Only completed paths were saved
CGContextDrawImage(context, targetRect, _frozenImage);
CGContextDrawImage(context, targetRect, _translucentFrozenImage);

// After: Include both completed and incomplete paths
CGContextDrawImage(context, targetRect, _frozenImage);
CGContextDrawImage(context, targetRect, _translucentFrozenImage);

// Include current incomplete path in saved image
if (_currentPath) {
    [_currentPath drawInContext:context];
}
```

**Key Benefits**:
- **Minimal Changes**: Only 6 lines added across two code paths
- **No Breaking Changes**: All existing functionality preserved
- **Backward Compatible**: Works with existing API
- **No New Functions**: Uses only existing native methods

## Testing
**Tested Scenarios**:
1. **Normal Operation**: Completed strokes save correctly (existing behavior)
2. **Timing Issues**: Incomplete strokes now included in saves
3. **System Interruptions**: Strokes preserved even when `endPath` is delayed
4. **Gesture Conflicts**: Incomplete strokes saved when gesture is interrupted

**Test Cases**:
- Draw complete stroke → Save → Stroke appears in image
- Start drawing → Save before lifting finger → Incomplete stroke appears in image
- Draw multiple strokes → Save during drawing → All visible strokes appear in image
- App interruption during drawing → Save → Partial stroke preserved

## Before/After
**Before**: Incomplete strokes visible on screen but missing from saved images
**After**: All visible strokes (complete and incomplete) are preserved in saved images

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code has been completed
- [x] Code has been tested locally
- [x] No new warnings or errors introduced
- [x] Changes are backward compatible

## Related Issues
- Fixes timing-dependent save failures
- Addresses user experience inconsistency
- Resolves data loss during interrupted drawing sessions