### PR TITLE
[FEAT] Add "onPanResponderTerminate" handler and refactor stroke end logic

### DIFF
--- a/src/SketchCanvas.tsx
+++ b/src/SketchCanvas.tsx
@@ -156,25 +156,11 @@ class SketchCanvas extends React.Component<SketchCanvasProps, CanvasState> {
         }
       },
       onPanResponderRelease: (_evt, _gestureState) => {
-        if (!this.props.touchEnabled) {
-          return;
-        }
-        if (this._path) {
-          this.props.onStrokeEnd?.({
-            path: this._path,
-            size: this._size,
-            drawer: this.props.user,
-          });
-          this._paths.push({
-            path: this._path,
-            size: this._size,
-            drawer: this.props.user,
-          });
-        }
+        this._handleStrokeEnd();
+      },
 
-        if (this.ref.current) {
-          Commands.endPath(this.ref.current);
-        }
+      onPanResponderTerminate: (_evt, _gestureState) => {
+        this._handleStrokeEnd();
       },
 
       onShouldBlockNativeResponder: (_evt, _gestureState) => {
@@ -182,6 +168,29 @@ class SketchCanvas extends React.Component<SketchCanvasProps, CanvasState> {
       },
     });
   }
+
+  _handleStrokeEnd = () => {
+    if (!this.props.touchEnabled) {
+      return;
+    }
+
+    if (this._path) {
+      this.props.onStrokeEnd?.({
+        path: this._path,
+        size: this._size,
+        drawer: this.props.user,
+      });
+      this._paths.push({
+        path: this._path,
+        size: this._size,
+        drawer: this.props.user,
+      });
+    }
+
+    if (this.ref.current) {
+      Commands.endPath(this.ref.current);
+    }
+  };
 
   _processText(text: any) {
     text &&


### PR DESCRIPTION
## 🐛 Bug Fixes
 - Properly handles `onStrokeEnd` not firing when gestures are interrupted by system events (incoming calls, notifications, app switching, etc.)
  - Ensures consistent stroke completion callbacks across iOS and Android platforms

 ## 🔧 Code Quality
  - Added onPanResponderTerminate handler to complement existing onPanResponderRelease

Both voluntary gesture release and forced gesture termination now properly finalize stroke data and trigger completion events, ensuring reliable drawing state tracking regardless of how the gesture ends.

Before

https://github.com/user-attachments/assets/aaceb0d5-3452-4934-b41e-04a119b74394

After

https://github.com/user-attachments/assets/e37db2bf-457f-484c-a332-e4f0f3d215d1

